### PR TITLE
fix setuptools warning about 'test_require'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,6 @@ setup(
     python_requires=">=3.7",
     extras_require={"dev": install_requires + testing_deps},
     test_suite="tests",
-    test_require=testing_deps,
+    tests_require=testing_deps,
     zip_safe=False,
 )


### PR DESCRIPTION
Running `python setup.py sdist` produces this warning

> miniconda3/lib/python3.7/distutils/dist.py:274: UserWarning: Unknown distribution option: 'test_require'
  warnings.warn(msg)

I think the right argument is `tests_require`.

This PR fixes that.