### PR TITLE
Adding option to set anon=True which will let user access S3 bucket anonymously

### DIFF
--- a/dask_pytorch_ddp/data.py
+++ b/dask_pytorch_ddp/data.py
@@ -34,7 +34,7 @@ def _list_all_files(bucket: str, prefix: str, s3_client=None) -> List[str]:
     return all_files
 
 
-def _read_s3_fileobj(bucket, path, fileobj, anon = False):
+def _read_s3_fileobj(bucket, path, fileobj, anon=False):
     """
     read an obj from s3 to a file like object
     """

--- a/dask_pytorch_ddp/data.py
+++ b/dask_pytorch_ddp/data.py
@@ -39,8 +39,8 @@ def _read_s3_fileobj(bucket, path, fileobj, anon=False):
     read an obj from s3 to a file like object
     """
     import boto3  # pylint: disable=import-outside-toplevel
-    from botocore import UNSIGNED
-    from botocore.client import Config
+    from botocore import UNSIGNED  # pylint: disable=import-outside-toplevel
+    from botocore.client import Config  # pylint: disable=import-outside-toplevel
 
     if anon:
         s3 = boto3.resource("s3", config=Config(signature_version=UNSIGNED))
@@ -64,6 +64,9 @@ class S3ImageFolder(Dataset):
     """
     An image folder that lives in S3.  Directories containing the image are classes.
     """
+
+    # pylint: disable=too-many-instance-attributes
+    # pylint: disable=too-many-arguments
 
     def __init__(
         self,

--- a/dask_pytorch_ddp/data.py
+++ b/dask_pytorch_ddp/data.py
@@ -8,6 +8,8 @@ from os.path import basename, dirname
 from typing import List, Callable, Optional
 from PIL import Image
 from torch.utils.data import Dataset
+from botocore import UNSIGNED
+from botocore.client import Config
 
 
 """

--- a/dask_pytorch_ddp/data.py
+++ b/dask_pytorch_ddp/data.py
@@ -40,7 +40,7 @@ def _read_s3_fileobj(bucket, path, fileobj, anon=False):
     """
     import boto3  # pylint: disable=import-outside-toplevel
 
-    if anon == True:
+    if anon:
         s3 = boto3.resource("s3", config=Config(signature_version=UNSIGNED))
     else:
         s3 = boto3.resource("s3")

--- a/dask_pytorch_ddp/data.py
+++ b/dask_pytorch_ddp/data.py
@@ -8,8 +8,6 @@ from os.path import basename, dirname
 from typing import List, Callable, Optional
 from PIL import Image
 from torch.utils.data import Dataset
-from botocore import UNSIGNED
-from botocore.client import Config
 
 
 """
@@ -25,7 +23,9 @@ def _list_all_files(bucket: str, prefix: str, s3_client=None) -> List[str]:
     Get list of all files from an s3 bucket matching a certain prefix
     """
     import boto3  # pylint: disable=import-outside-toplevel
-
+    from botocore import UNSIGNED
+    from botocore.client import Config
+    
     if s3_client is None:
         s3_client = boto3.client("s3")
     paginator = s3_client.get_paginator("list_objects")

--- a/dask_pytorch_ddp/data.py
+++ b/dask_pytorch_ddp/data.py
@@ -23,9 +23,7 @@ def _list_all_files(bucket: str, prefix: str, s3_client=None) -> List[str]:
     Get list of all files from an s3 bucket matching a certain prefix
     """
     import boto3  # pylint: disable=import-outside-toplevel
-    from botocore import UNSIGNED
-    from botocore.client import Config
-    
+
     if s3_client is None:
         s3_client = boto3.client("s3")
     paginator = s3_client.get_paginator("list_objects")
@@ -41,6 +39,8 @@ def _read_s3_fileobj(bucket, path, fileobj, anon=False):
     read an obj from s3 to a file like object
     """
     import boto3  # pylint: disable=import-outside-toplevel
+    from botocore import UNSIGNED
+    from botocore.client import Config
 
     if anon:
         s3 = boto3.resource("s3", config=Config(signature_version=UNSIGNED))

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -40,7 +40,7 @@ def test_image_folder_getitem():
         read_s3_fileobj.return_value = Mock()
         load_image_obj.return_value = Mock()
         val, label = folder[0]
-        read_s3_fileobj.assert_called_once_with("fake-bucket", fake_file_list[0], ANY)
+        read_s3_fileobj.assert_called_once_with("fake-bucket", fake_file_list[0], ANY, False)
         load_image_obj.assert_called_once_with(read_s3_fileobj())
         assert val == load_image_obj.return_value
         assert label == 1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -40,9 +40,7 @@ def test_image_folder_getitem():
         read_s3_fileobj.return_value = Mock()
         load_image_obj.return_value = Mock()
         val, label = folder[0]
-        read_s3_fileobj.assert_called_once_with(
-            "fake-bucket", fake_file_list[0], ANY, False
-        )
+        read_s3_fileobj.assert_called_once_with("fake-bucket", fake_file_list[0], ANY, False)
         load_image_obj.assert_called_once_with(read_s3_fileobj())
         assert val == load_image_obj.return_value
         assert label == 1

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -40,7 +40,9 @@ def test_image_folder_getitem():
         read_s3_fileobj.return_value = Mock()
         load_image_obj.return_value = Mock()
         val, label = folder[0]
-        read_s3_fileobj.assert_called_once_with("fake-bucket", fake_file_list[0], ANY, False)
+        read_s3_fileobj.assert_called_once_with(
+            "fake-bucket", fake_file_list[0], ANY, False
+        )
         load_image_obj.assert_called_once_with(read_s3_fileobj())
         assert val == load_image_obj.return_value
         assert label == 1


### PR DESCRIPTION
Problem: 
dask-pytorch-ddp is assuming signed (aka non-anon) connections. 

Solution:
add an anon flag to S3ImageFolder then use unsigned connections if its true

The flag defaults to False (preserves current behavior).